### PR TITLE
Layout Workshop detail pages with WorkshopLayout

### DIFF
--- a/src/components/Workshops/WorkshopLayout.js
+++ b/src/components/Workshops/WorkshopLayout.js
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default ({ children }) => <div
+    style={{
+        padding: "2rem",
+        color: "#000000",
+        backgroundColor: "#D1D9E4"
+    }}>
+    {children}
+</div>

--- a/src/pages/workshops/apps-with-kubernetes.mdx
+++ b/src/pages/workshops/apps-with-kubernetes.mdx
@@ -1,14 +1,6 @@
-import { graphql } from "gatsby";
-import Layout from "../../components/layout";
-import { Flex } from "@rebass/grid";
+import WorkshopLayout from '../../components/Workshops/WorkshopLayout';
 
-<Flex
-  flexDirection="row"
-  flexWrap="wrap"
-  alignItems="center"
-  justifyContent="flex-start"
-  style={{ padding: "2rem", width: "", color: "#000000", backgroundColor: "#D1D9E4" }}
->
+<WorkshopLayout>
 
 # Developing Applications with Kubernetes ☸
 
@@ -30,6 +22,6 @@ Anyone interested in getting a hands on overview of Kubernetes, whether they are
 **Take back to work:**
 The take away should be a firm understanding of the Kubernetes environment, and how one develops for it. It aims to expose some of the benefits of the platform so that people who are evaluating bringing it into their environment can have a deeper sense of what application development looks like on it.
 
-</Flex>
+</WorkshopLayout>
 
 ---

--- a/src/pages/workshops/frontend-performance.mdx
+++ b/src/pages/workshops/frontend-performance.mdx
@@ -1,13 +1,6 @@
-import Layout from "../../components/layout";
-import { Flex } from "@rebass/grid";
+import WorkshopLayout from '../../components/Workshops/WorkshopLayout';
 
-<Flex
-  flexDirection="column"
-  flexWrap="wrap"
-  alignItems="center"
-  justifyContent="center"
-  style={{ padding: "2rem", width: "", color: "#000000", backgroundColor: "#D1D9E4" }}
->
+<WorkshopLayout>
 
 # Get in the Fast Lane: Measuring React Performance 🚀
 
@@ -35,6 +28,6 @@ We will profile real applications to both learn the tools of measurement as well
 
 **Preparation**: Please come with a laptop ready for development. You must have Chrome, the [React DevTools extension](https://chrome.google.com/webstore/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi?hl=en), and [Node (v 8+)](https://www.nodejs.org) installed.
 
-</Flex>
+</WorkshopLayout>
 
 ---

--- a/src/pages/workshops/practical-css-grid.mdx
+++ b/src/pages/workshops/practical-css-grid.mdx
@@ -1,13 +1,6 @@
-import Layout from "../../components/layout";
-import { Flex } from "@rebass/grid";
+import WorkshopLayout from '../../components/Workshops/WorkshopLayout';
 
-<Flex
-  flexDirection="column"
-  flexWrap="wrap"
-  alignItems="first-baseline"
-  justifyContent="flex-start"
-  style={{ padding: "2rem", width: "", color: "#000000", backgroundColor: "#D1D9E4"}}
->
+<WorkshopLayout>
 
 # Practical CSS Grid: Get started with Grid with practical, reusable code
 
@@ -27,6 +20,6 @@ In this workshop, we’ll cover all the basics and advanced maneuvers of Grid in
 
 **Preparation:** Bring a laptop with FireFox Nightly installed. You don't have to use FireFox, but it's easily the best browser to use to work with Grid.
 
-</Flex>
+</WorkshopLayout>
 
 ---

--- a/src/pages/workshops/web-components.mdx
+++ b/src/pages/workshops/web-components.mdx
@@ -1,13 +1,6 @@
-import Layout from "../../components/layout";
-import { Flex } from "@rebass/grid";
+import WorkshopLayout from '../../components/Workshops/WorkshopLayout';
 
-<Flex
-  flexDirection="row"
-  flexWrap="wrap"
-  alignItems="start"
-  justifyContent="flex-start"
-  style={{ padding: "2rem", width: "", color: "#000000", backgroundColor: "#D1D9E4" }}
->
+<WorkshopLayout>
 
 # Zero Dependency Components: Introduction to Web Components 🕸
 
@@ -45,6 +38,6 @@ If you aren't comfortable with ES6, that is OK. Bring a buddy! Pairing is encour
 
 **Preparation:** Please bring a laptop with a modern browser and your favorite editor.
 
-</Flex>
+</WorkshopLayout>
 
 ---


### PR DESCRIPTION
A couple pages (web-components, frontend-performance) seemed to have layout issues due to differences in flexbox usage.

This introduces a WorkshopLayout component to centralize styling for the detail pages. It also removes flexbox usage. I may have missed something, but I couldn't see what flexbox achieved over standard `block` display.

How does this look?